### PR TITLE
Tag commit before making a release

### DIFF
--- a/src/versioning.js
+++ b/src/versioning.js
@@ -44,7 +44,17 @@ const versioning = (gitClient, config, release) => {
                     return reject(inner_err);
                   }
                 })
+                .addTag(`v${targetVersion}`, (inner_err) => {
+                  if (inner_err) {
+                    return reject(inner_err);
+                  }
+                })
                 .push((inner_err) => {
+                  if (inner_err) {
+                    return reject(inner_err);
+                  }
+                })
+                .pushTags((inner_err) => {
                   if (inner_err) {
                     return reject(inner_err);
                   }


### PR DESCRIPTION
This ensures that the tag goes on the version bump instead of the head
of the default branch.